### PR TITLE
Add rust-rgb compatability

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,9 +17,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --verbose --all-features
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --verbose --all-features
 
     - name: Tarpaulin code coverage
       id: coverage

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,10 @@ exclude = [
 	"tests/*",
 ]
 
+[features]
+default = []
+rust-rgb = ["rgb"]
+
 [dependencies]
 phf = {version="0.8.0", features=["macros"]}
+rgb = {version = "0.8.25", optional = true}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,8 @@ use std::error::Error as StdError;
 use std::f64::consts::PI;
 use std::fmt;
 use std::str::FromStr;
+#[cfg(feature = "rust-rgb")]
+use rgb::{RGB, RGBA};
 
 /// The color
 #[derive(Debug, Clone, PartialEq)]
@@ -520,6 +522,22 @@ impl FromStr for Color {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         parse(s)
+    }
+}
+
+/// Convert rust-rgb's `RGB<f64>` type into `Color`.
+#[cfg(feature = "rust-rgb")]
+impl From<RGB<f64>> for Color {
+    fn from(item: RGB<f64>) -> Self {
+        Color::from_rgb(item.r, item.g, item.b)
+    }
+}
+
+/// Convert rust-rgb's `RGBA<f64>` type into `Color`.
+#[cfg(feature = "rust-rgb")]
+impl From<RGBA<f64>> for Color {
+    fn from(item: RGBA<f64>) -> Self {
+        Color::from_rgba(item.r, item.g, item.b, item.a)
     }
 }
 
@@ -1115,5 +1133,17 @@ mod tests {
             let v = interp_angle(a, b, t);
             assert_eq!(expected, v);
         }
+    }
+
+    #[cfg(feature = "rust-rgb")]
+    #[test]
+    fn convert_rust_rgb_to_color() {
+        let rgb = RGB::new(0.0, 0.5, 1.0);
+
+        assert_eq!(Color::from_rgb(0.0, 0.5, 1.0), Color::from(rgb));
+
+        let rgba = RGBA::new(1.0, 0.5, 0.0, 0.5);
+
+        assert_eq!(Color::from_rgba(1.0, 0.5, 0.0, 0.5), Color::from(rgba));
     }
 }


### PR DESCRIPTION
Instead of replacing the base `Color` type, I decided it would be more approachable to instead use `From` to convert `rust-rgb`'s `RGB/RGBA` types into `Color`.

Closes #1