### PR TITLE
Add support for Serde serialization/deserialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,7 @@ rust-rgb = ["rgb"]
 [dependencies]
 phf = { version = "0.8.0", optional = true, features = ["macros"] }
 rgb = { version = "0.8.25", optional = true }
+serde = { version = "1.0", optional = true, features = ["derive"] }
 
+[dev-dependencies]
+serde_test = "1.0"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@
 
 Not yet supported: `lab()`, `lch()`.
 
+## Optional Features
+
+* `rust-rgb`: Enables converting from [`rgb`](https://crates.io/crates/rgb) crate types into `Color`.
+* `serde`: Enables serializing (into HEX string) and deserializing (from any supported string color format) using [`serde`](https://serde.rs/) framework.
+
 ### Example Color Format
 
 ```text


### PR DESCRIPTION
This adds optional support for [Serde](https://serde.rs/) serialization/deserialization framework. This enables serializing (into HEX strings) and deserializing (from any string color format) for all data formats with strings that Serde supports.