### PR TITLE
Spec type fixes: hsl hsv hwb

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -176,8 +176,8 @@ pub fn parse(s: &str) -> Result<Color, ParseColorError> {
                 }
 
                 let h = parse_angle(params[0]);
-                let s = parse_percent_or_float(params[1]);
-                let v = parse_percent_or_float(params[2]);
+                let s = parse_percent(params[1]);
+                let v = parse_percent(params[2]);
 
                 let a = if p_len == 4 {
                     parse_percent_or_float(params[3])

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -134,8 +134,8 @@ pub fn parse(s: &str) -> Result<Color, ParseColorError> {
                 }
 
                 let h = parse_angle(params[0]);
-                let s = parse_percent_or_float(params[1]);
-                let l = parse_percent_or_float(params[2]);
+                let s = parse_percent(params[1]);
+                let l = parse_percent(params[2]);
 
                 let a = if p_len == 4 {
                     parse_percent_or_float(params[3])

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -288,12 +288,18 @@ fn parse_hex(s: &str) -> Result<Color, Box<dyn error::Error>> {
     Ok(Color::from_rgba_u8(r, g, b, a))
 }
 
-fn parse_percent_or_float(s: &str) -> Option<f64> {
+fn parse_percent(s: &str) -> Option<f64> {
     if let Some(s) = s.strip_suffix('%') {
         if let Ok(t) = s.parse::<f64>() {
             return Some(t / 100.0);
         }
-        return None;
+    }
+    None
+}
+
+fn parse_percent_or_float(s: &str) -> Option<f64> {
+    if let Some(percent) = parse_percent(s) {
+        return Some(percent);
     }
 
     if let Ok(t) = s.parse::<f64>() {
@@ -304,11 +310,8 @@ fn parse_percent_or_float(s: &str) -> Option<f64> {
 }
 
 fn parse_percent_or_255(s: &str) -> Option<f64> {
-    if let Some(s) = s.strip_suffix('%') {
-        if let Ok(t) = s.parse::<f64>() {
-            return Some(t / 100.0);
-        }
-        return None;
+    if let Some(percent) = parse_percent(s) {
+        return Some(percent);
     }
 
     if let Ok(t) = s.parse::<f64>() {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -155,8 +155,8 @@ pub fn parse(s: &str) -> Result<Color, ParseColorError> {
                 }
 
                 let h = parse_angle(params[0]);
-                let w = parse_percent_or_float(params[1]);
-                let b = parse_percent_or_float(params[2]);
+                let w = parse_percent(params[1]);
+                let b = parse_percent(params[2]);
 
                 let a = if p_len == 4 {
                     parse_percent_or_float(params[3])

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -45,7 +45,10 @@ fn parser() {
 #[test]
 fn parser_invalid_syntax() {
     let test_data: Vec<(&str,  ParseColorError)> =
-        vec![("hsl(270deg 0 0.5)", ParseColorError::InvalidHsl)];
+        vec![
+            ("hsl(270deg 0 0.5)", ParseColorError::InvalidHsl),
+            ("hwb(270deg 0 0.5)", ParseColorError::InvalidHwb),
+        ];
 
     for (s, expected) in test_data {
         let a = parse(s);

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -1,4 +1,4 @@
-use csscolorparser::{parse, Color};
+use csscolorparser::{parse, Color, ParseColorError};
 
 #[test]
 fn parser() {
@@ -39,6 +39,24 @@ fn parser() {
         for (s, expected) in test_data {
             assert_eq!(expected, parse(s).unwrap().rgba_u8());
         }
+    }
+}
+
+#[test]
+fn parser_invalid_syntax() {
+    let test_data: Vec<(&str,  ParseColorError)> =
+        vec![("hsl(270deg 0 0.5)", ParseColorError::InvalidHsl)];
+
+    for (s, expected) in test_data {
+        let a = parse(s);
+        let b = s.parse::<Color>();
+        let c = Color::from_html(s);
+        assert!(a.is_err());
+        assert!(b.is_err());
+        assert!(c.is_err());
+        assert_eq!(a.unwrap_err(), expected);
+        assert_eq!(b.unwrap_err(), expected);
+        assert_eq!(c.unwrap_err(), expected);
     }
 }
 

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -44,12 +44,15 @@ fn parser() {
 
 #[test]
 fn parser_invalid_syntax() {
-    let test_data: Vec<(&str,  ParseColorError)> =
-        vec![
-            ("hsl(270deg 0 0.5)", ParseColorError::InvalidHsl),
-            ("hwb(270deg 0 0.5)", ParseColorError::InvalidHwb),
-            ("hsv(270deg 0 0.5)", ParseColorError::InvalidHsv),
-        ];
+    let test_data = vec![
+        // Spec only allows percentage for second and third parameter.
+        ("hsl(270deg 0 50%)", ParseColorError::InvalidHsl),
+        ("hsl(270deg 0% 0.5)", ParseColorError::InvalidHsl),
+        ("hwb(270deg 0 50%)", ParseColorError::InvalidHwb),
+        ("hwb(270deg 0% 0.5)", ParseColorError::InvalidHwb),
+        ("hsv(270deg 0 50%)", ParseColorError::InvalidHsv),
+        ("hsv(270deg 0% 0.5)", ParseColorError::InvalidHsv),
+    ];
 
     for (s, expected) in test_data {
         let a = parse(s);

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -48,6 +48,7 @@ fn parser_invalid_syntax() {
         vec![
             ("hsl(270deg 0 0.5)", ParseColorError::InvalidHsl),
             ("hwb(270deg 0 0.5)", ParseColorError::InvalidHwb),
+            ("hsv(270deg 0 0.5)", ParseColorError::InvalidHsv),
         ];
 
     for (s, expected) in test_data {


### PR DESCRIPTION
This PR aims to fix a few cases where the parser allows more than what the spec allows, such as float values where only percentages are allowed. See the individual commits for details.