### PR TITLE
Fix error when parsing hex value with non-ASCII

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -255,6 +255,10 @@ pub fn parse(s: &str) -> Result<Color, ParseColorError> {
 }
 
 fn parse_hex(s: &str) -> Result<Color, Box<dyn error::Error>> {
+    if !s.is_ascii() {
+        return Err(Box::new(ParseColorError::InvalidHex));
+    }
+
     let n = s.len();
 
     let (r, g, b, a) = if n == 3 || n == 4 {

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -195,7 +195,7 @@ fn lime_alpha() {
     }
 }
 
-#[cfg(all(feature = "named-colors", features = "lab"))]
+#[cfg(all(feature = "named-colors", feature = "lab"))]
 #[test]
 fn invalid_format() {
     let test_data = vec![
@@ -240,6 +240,10 @@ fn invalid_format() {
         ("cmyk(0,0,0,0)", "Invalid color function."),
         ("blood", "Invalid unknown format."),
         ("rgb(255,0,0", "Invalid unknown format."),
+        ("x£", "Invalid unknown format."),
+        ("x£x", "Invalid unknown format."),
+        ("xxx£x", "Invalid unknown format."),
+        ("xxxxx£x", "Invalid unknown format."),
     ];
 
     for (s, err_msg) in test_data {


### PR DESCRIPTION
Previously, the string slicing below would panic because they hit invalid UTF8 characters