### PR TITLE
improve error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ lab = { version = "0.11.0", optional = true }
 phf = { version = "0.10.1", optional = true, features = ["macros"] }
 rgb = { version = "0.8.32", optional = true }
 serde = { version = "1.0.137", optional = true, features = ["derive"] }
+thiserror = "1.0.31"
 
 [dev-dependencies]
 serde_test = "1.0.137"


### PR DESCRIPTION
- Use [thiserror](https://github.com/dtolnay/thiserror) to avoid implementing `Error` trait manually.
- `Box` has performance overhead, and this PR removes it.