### PR TITLE
mark color name lifetime explicitly

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -398,7 +398,7 @@ impl Color {
     }
 
     #[cfg(feature = "named-colors")]
-    pub fn name(&self) -> Option<&str> {
+    pub fn name(&self) -> Option<&'static str> {
         let rgb = &self.to_rgba8()[0..3];
         for (&k, &v) in NAMED_COLORS.entries() {
             if v == rgb {


### PR DESCRIPTION
By default, Rust will treat the lifetime of `&str` is same as `&self`, which may cause unexpected problems. This fix avoids it.