### PR TITLE
Fix CI: Replace broken actions-rs/tarpaulin with cargo-tarpaulin

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,7 +33,7 @@ jobs:
       id: coverage
       run: |
         cargo install cargo-tarpaulin
-        cargo tarpaulin -o lcov
+        cargo tarpaulin -o xml
 
     - name: Upload to codecov.io
       uses: codecov/codecov-action@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Build
       run: cargo build --verbose --all-features
@@ -31,10 +31,12 @@ jobs:
 
     - name: Tarpaulin code coverage
       id: coverage
-      uses: actions-rs/tarpaulin@v0.1
+      run: |
+        cargo install cargo-tarpaulin
+        cargo tarpaulin -o lcov
 
     - name: Upload to codecov.io
-      uses: codecov/codecov-action@v1.0.2
+      uses: codecov/codecov-action@v3
       with:
         token: ${{secrets.CODECOV_TOKEN}}
 


### PR DESCRIPTION
`actions-rs/tarpaulin` appears to be abandoned.

## Changes

- Replaced `actions-rs/tarpaulin` with `cargo-tarpaulin`, allowing coverage report to be submitted to codecov successfully.
- Bumped `actions/checkout` and `codecov/codecov-action`

Here's my codecov report: <https://app.codecov.io/github/elliotwutingfeng/csscolorparser-rs/tree/master/src>