### PR TITLE
fix: Make `Color::Name` returns `None` if a color has the same RGB as a named color, but is not fully opaque

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -416,8 +416,14 @@ impl Color {
     }
 
     #[cfg(feature = "named-colors")]
+    /// Returns name of this color, returning [`None`] if it is not available.
     pub fn name(&self) -> Option<&'static str> {
-        let rgb = &self.to_rgba8()[0..3];
+        let rgba = self.to_rgba8();
+        let rgb = if rgba[3] == u8::MAX {
+            &rgba[0..3]
+        } else {
+            return None;
+        };
         for (&k, &v) in NAMED_COLORS.entries() {
             if v == rgb {
                 return Some(k);

--- a/tests/named_colors.rs
+++ b/tests/named_colors.rs
@@ -62,4 +62,26 @@ fn named_colors() {
     for c in test_data {
         assert!(c.name().is_none());
     }
+
+    // 8 digits hex code with fully opaque alpha component
+
+    let test_data = [
+        ("#f0f8ffff", "aliceblue"),
+        ("#ffe4c4ff", "bisque"),
+        ("#7fff00ff", "chartreuse"),
+        ("#ff7f50ff", "coral"),
+    ];
+
+    for (hex, name) in test_data {
+        let c = csscolorparser::parse(hex).unwrap();
+        assert_eq!(c.name(), Some(name));
+    }
+
+    // RGB is the same as named colors, but is not fully opaque
+
+    let test_data = ["#f0f8ff3f", "#ffe4c47f", "#7fff00bf"];
+    for hex in test_data {
+        let c = csscolorparser::parse(hex).unwrap();
+        assert!(c.name().is_none());
+    }
 }


### PR DESCRIPTION
Same as mazznoer/csscolorparser#3.