### PR TITLE
Support no_std environments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,8 @@ exclude = [
 features = ["named-colors", "lab", "rust-rgb", "cint", "serde"]
 
 [features]
-default = ["named-colors"]
+default = ["named-colors", "std"]
+std = ["phf/std"]
 lab = []
 named-colors = ["phf"]
 rust-rgb = ["rgb"]
@@ -26,6 +27,7 @@ rust-rgb = ["rgb"]
 [dependencies]
 cint = { version = "^0.3.1", optional = true }
 phf = { version = "0.13.1", optional = true, features = ["macros"] }
+num-traits = { version = "0.2.19", default-features = false, features = ["libm"] }
 rgb = { version = "0.8.33", optional = true }
 serde = { version = "1.0.139", optional = true, features = ["derive"] }
 

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,6 +1,6 @@
-use std::convert::TryFrom;
-use std::fmt;
-use std::str::FromStr;
+use core::convert::TryFrom;
+use core::fmt;
+use core::str::FromStr;
 
 #[cfg(feature = "rust-rgb")]
 use rgb::{RGB, RGBA};
@@ -13,6 +13,13 @@ use crate::lab::{lab_to_linear_rgb, linear_rgb_to_lab};
 
 use crate::utils::*;
 use crate::{parse, ParseColorError};
+
+use alloc::format;
+use alloc::string::String;
+use alloc::string::ToString;
+
+#[cfg(not(feature = "std"))]
+use num_traits::float::Float;
 
 #[cfg(feature = "named-colors")]
 use crate::NAMED_COLORS;
@@ -169,7 +176,7 @@ impl Color {
     /// # Examples
     /// ```
     /// use csscolorparser::Color;
-    /// # use std::error::Error;
+    /// # use core::error::Error;
     /// # fn main() -> Result<(), Box<dyn Error>> {
     ///
     /// let c = Color::from_html("rgb(255,0,0)")?;
@@ -450,7 +457,7 @@ impl Color {
     #[cfg(feature = "lab")]
     /// Get CSS `lch()` color representation
     pub fn to_css_lch(&self) -> String {
-        use std::f32::consts::PI;
+        use core::f32::consts::PI;
 
         fn to_degrees(t: f32) -> f32 {
             if t > 0.0 {

--- a/src/color2.rs
+++ b/src/color2.rs
@@ -2,6 +2,11 @@
 
 use crate::Color;
 
+use alloc::string::String;
+
+#[cfg(not(feature = "std"))]
+use num_traits::float::Float;
+
 impl Color {
     #[deprecated = "Use [new](#method.new) instead."]
     /// Arguments:

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
-use std::error::Error;
-use std::fmt;
+use core::error::Error;
+use core::fmt;
 
 /// An error which can be returned when parsing a CSS color string.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use num_traits::float::Float;
+
 // Constants for D65 white point (normalized to Y=1.0)
 const D65_X: f32 = 0.95047;
 const D65_Y: f32 = 1.0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@
 //! Using [`csscolorparser::parse()`](fn.parse.html) function.
 //!
 //! ```rust
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # fn main() -> Result<(), Box<dyn core::error::Error>> {
 //! let c = csscolorparser::parse("rgb(100%,0%,0%)")?;
 //!
 //! assert_eq!(c.to_array(), [1.0, 0.0, 0.0, 1.0]);
@@ -47,7 +47,7 @@
 //!
 //! ```rust
 //! use csscolorparser::Color;
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # fn main() -> Result<(), Box<dyn core::error::Error>> {
 //!
 //! let c: Color = "#ff00007f".parse()?;
 //!
@@ -70,6 +70,11 @@
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
+#![no_std]
+#[cfg(feature = "std")]
+extern crate std;
+
+extern crate alloc;
 
 mod color;
 mod color2;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -9,7 +9,7 @@ use crate::NAMED_COLORS;
 /// # Examples
 ///
 /// ```
-/// # use std::error::Error;
+/// # use core::error::Error;
 /// # fn main() -> Result<(), Box<dyn Error>> {
 /// let c = csscolorparser::parse("#ff0")?;
 ///
@@ -22,7 +22,7 @@ use crate::NAMED_COLORS;
 /// ```
 ///
 /// ```
-/// # use std::error::Error;
+/// # use core::error::Error;
 /// # fn main() -> Result<(), Box<dyn Error>> {
 /// let c = csscolorparser::parse("hsl(360deg,100%,50%)")?;
 ///
@@ -687,6 +687,7 @@ fn parse_angle(s: &str) -> Option<f32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec::Vec;
 
     #[test]
     fn test_strip_prefix() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,8 +1,11 @@
 #[cfg(feature = "lab")]
-use std::f32::consts::{PI, TAU};
+use core::f32::consts::{PI, TAU};
 
 #[cfg(feature = "lab")]
 const PI_3: f32 = PI * 3.0;
+
+#[cfg(not(feature = "std"))]
+use num_traits::float::Float;
 
 #[allow(clippy::excessive_precision)]
 pub(crate) fn oklab_to_linear_rgb(l: f32, a: f32, b: f32) -> [f32; 3] {
@@ -202,6 +205,7 @@ pub(crate) const fn remap(t: f32, a: f32, b: f32, c: f32, d: f32) -> f32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
 
     #[test]
     fn test_normalize_angle() {

--- a/tests/color.rs
+++ b/tests/color.rs
@@ -1,5 +1,5 @@
+use core::convert::TryFrom;
 use csscolorparser::Color;
-use std::convert::TryFrom;
 
 #[test]
 fn basic() {
@@ -106,7 +106,7 @@ fn basic() {
 
 #[test]
 fn parser() {
-    use std::str::FromStr;
+    use core::str::FromStr;
     let test_data = ["#71fe15", "#d6e3c9", "#2a7719", "#b53717", "#5b0b8d"];
     for s in test_data {
         let c = Color::from_str(s).unwrap();


### PR DESCRIPTION
This PR makes it possible to use `csscolorparser` in `no_std` environments by:

- Adding the opt-out `std` feature flag
- Using the `core` crate instead of the `std` crate when the `std` feature is disabled
- Disabling the `std` feature of `phf` when the `std` feature is disabled
