### PR TITLE
Update `phf` to 0.13.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ rust-rgb = ["rgb"]
 
 [dependencies]
 cint = { version = "^0.3.1", optional = true }
-phf = { version = "0.11.0", optional = true, features = ["macros"] }
+phf = { version = "0.13.1", optional = true, features = ["macros"] }
 rgb = { version = "0.8.33", optional = true }
 serde = { version = "1.0.139", optional = true, features = ["derive"] }
 


### PR DESCRIPTION
This removes a few dependencies for downstream crates.